### PR TITLE
DDF-311 Add additional temporal filters

### DIFF
--- a/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/SolrProviderTestCase.java
+++ b/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/SolrProviderTestCase.java
@@ -18,9 +18,11 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
 import org.junit.BeforeClass;
 import org.opengis.filter.Filter;
 import org.slf4j.Logger;
@@ -53,11 +55,16 @@ public abstract class SolrProviderTestCase {
 
     protected static final String MASKED_ID = "scp";
 
-    protected static FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+    protected static TestSolrFilterBuilder filterBuilder = new TestSolrFilterBuilder();
 
     protected static SolrCatalogProvider provider = null;
 
     private static final int TEST_METHOD_NAME_INDEX = 3;
+
+    private static final int ONE_SECOND = 1;
+    private static final int TIME_STEP_10SECONDS = 10 * ONE_SECOND;
+    private static final int TIME_STEP_30SECONDS = 30 * ONE_SECOND;
+    private static final int A_LITTLE_WHILE = TIME_STEP_10SECONDS;
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -166,4 +173,31 @@ public abstract class SolrProviderTestCase {
         return createResponse;
     }
 
+    protected List<Metacard> addMetacardWithModifiedDate(DateTime now) throws IngestException {
+        List<Metacard> list = new ArrayList<Metacard>();
+        MockMetacard m = new MockMetacard(Library.getFlagstaffRecord());
+        m.setEffectiveDate(dateNow(now));
+        list.add(m);
+        create(list);
+        return list;
+    }
+
+    protected List<Result> getResultsForFilteredQuery(Filter filter) throws UnsupportedQueryException {
+        QueryImpl query = new QueryImpl(filter);
+
+        SourceResponse sourceResponse = provider.query(new QueryRequestImpl(query));
+        return sourceResponse.getResults();
+    }
+
+    protected Date dateAfterNow(DateTime now) {
+        return now.plusSeconds(A_LITTLE_WHILE).toDate();
+    }
+
+    protected Date dateBeforeNow(DateTime now) {
+        return now.minusSeconds(A_LITTLE_WHILE).toDate();
+    }
+
+    protected Date dateNow(DateTime now) {
+        return now.toDate();
+    }
 }

--- a/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/TestSolrFilterBuilder.java
+++ b/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/TestSolrFilterBuilder.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+package ddf.catalog.source.solr;
+
+import java.util.Date;
+
+import org.geotools.filter.FilterFactoryImpl;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory;
+
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+
+public class TestSolrFilterBuilder extends GeotoolsFilterBuilder {
+
+    private FilterFactory factory = new FilterFactoryImpl();
+
+    public Filter dateLessThan(String attribute, Date literal) {
+        return factory.less(factory.property(attribute), factory.literal(literal));
+    }
+
+    public Filter dateLessThanOrEqual(String attribute, Date literal) {
+        return factory.lessOrEqual(factory.property(attribute), factory.literal(literal));
+    }
+
+    public Filter dateGreaterThan(String attribute, Date literal) {
+        return factory.greater(factory.property(attribute), factory.literal(literal));
+    }
+
+    public Filter dateGreaterThanOrEqual(String attribute, Date literal) {
+        return factory.greaterOrEqual(factory.property(attribute), factory.literal(literal));
+    }
+}

--- a/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/TestSolrFilterDelegate.java
+++ b/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/TestSolrFilterDelegate.java
@@ -14,6 +14,10 @@
  **/
 package ddf.catalog.source.solr;
 
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -150,4 +154,65 @@ public class TestSolrFilterDelegate {
     }
     END OMIT per DDF-314*/
 
+    @Test
+    public void testTemporalBefore() {
+        stub(mockResolver.getField("created", AttributeFormat.DATE, false)).toReturn("created_date");
+
+        String expectedQuery = " created_date:[ * TO 1995-11-24T23:59:56.765Z } ";
+        SolrQuery temporalQuery = toTest.before(Metacard.CREATED, getCannedTime());
+        assertThat(temporalQuery.getQuery(), is(expectedQuery));
+    }
+
+    @Test
+    public void testTemporalAfter() {
+        stub(mockResolver.getField("created", AttributeFormat.DATE, false)).toReturn("created_date");
+
+        String expectedQuery = " created_date:{ 1995-11-24T23:59:56.765Z TO * ] ";
+        SolrQuery temporalQuery = toTest.after(Metacard.CREATED, getCannedTime());
+        assertThat(temporalQuery.getQuery(), is(expectedQuery));
+    }
+
+    @Test
+    public void testDatePropertyGreaterThan() {
+        stub(mockResolver.getField("created", AttributeFormat.DATE, false)).toReturn("created_date");
+
+        String expectedQuery = " created_date:{ 1995-11-24T23:59:56.765Z TO * ] ";
+        SolrQuery temporalQuery = toTest.propertyIsGreaterThan(Metacard.CREATED, getCannedTime());
+        assertThat(temporalQuery.getQuery(), is(expectedQuery));
+    }
+
+    @Test
+    public void testDatePropertyGreaterThanOrEqualTo() {
+        stub(mockResolver.getField("created", AttributeFormat.DATE, false)).toReturn("created_date");
+
+        String expectedQuery = " created_date:[ 1995-11-24T23:59:56.765Z TO * ] ";
+        SolrQuery temporalQuery = toTest.propertyIsGreaterThanOrEqualTo(Metacard.CREATED, getCannedTime());
+        assertThat(temporalQuery.getQuery(), is(expectedQuery));
+    }
+
+    @Test
+    public void testDatePropertyLessThan() {
+        stub(mockResolver.getField("created", AttributeFormat.DATE, false)).toReturn("created_date");
+
+        String expectedQuery = " created_date:[ * TO 1995-11-24T23:59:56.765Z } ";
+        SolrQuery temporalQuery = toTest.propertyIsLessThan(Metacard.CREATED, getCannedTime());
+        assertThat(temporalQuery.getQuery(), is(expectedQuery));
+    }
+
+    @Test
+    public void testDatePropertyLessThanOrEqualTo() {
+        stub(mockResolver.getField("created", AttributeFormat.DATE, false)).toReturn("created_date");
+
+        String expectedQuery = " created_date:[ * TO 1995-11-24T23:59:56.765Z ] ";
+        SolrQuery temporalQuery = toTest.propertyIsLessThanOrEqualTo(Metacard.CREATED, getCannedTime());
+        assertThat(temporalQuery.getQuery(), is(expectedQuery));
+    }
+
+    private Date getCannedTime() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.clear();
+        calendar.set(1995, Calendar.NOVEMBER, 24, 23, 59, 56);
+        calendar.set(Calendar.MILLISECOND, 765);
+        return calendar.getTime();
+    }
 }

--- a/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/TestSolrProvider.java
+++ b/embedded/catalog-solr-embedded-provider/src/test/java/ddf/catalog/source/solr/TestSolrProvider.java
@@ -2915,33 +2915,114 @@ public class TestSolrProvider extends SolrProviderTestCase {
 
         deleteAllIn(provider);
 
-        Metacard metacard = new MockMetacard(Library.getFlagstaffRecord());
-        List<Metacard> list = Arrays.asList(metacard);
-
-        create(list);
+        DateTime now = new DateTime();
+        List<Metacard> list = addMetacardWithModifiedDate(now);
 
         /** POSITIVE CASE **/
-        Filter filter = filterBuilder.attribute(Metacard.MODIFIED).before()
-                .date(new DateTime().plus(1).toDate());
-
-        QueryImpl query = new QueryImpl(filter);
-
-        SourceResponse sourceResponse = provider.query(new QueryRequestImpl(query));
-
-        assertEquals(1, sourceResponse.getResults().size());
+        Filter filter = filterBuilder.attribute(Metacard.MODIFIED).before().date(dateAfterNow(now));
+        List<Result> results = getResultsForFilteredQuery(filter);
+        assertEquals(1, results.size());
 
         /** NEGATIVE CASE **/
-        filter = filterBuilder.attribute(Metacard.MODIFIED).before()
-                .date(new DateTime().minus(10000).toDate());
+        filter = filterBuilder.attribute(Metacard.MODIFIED).before().date(dateBeforeNow(now));
+        results = getResultsForFilteredQuery(filter);
+        assertEquals(0, results.size());
 
-        query = new QueryImpl(filter);
+    }
 
-        sourceResponse = provider.query(new QueryRequestImpl(query));
+    @Test()
+    public void testTemporalAfter() throws Exception {
 
-        assertEquals(0, sourceResponse.getResults().size());
+        deleteAllIn(provider);
 
-        /** Test Sort **/
+        DateTime now = new DateTime();
+        List<Metacard> list = addMetacardWithModifiedDate(now);
 
+        /** POSITIVE CASE **/
+        Filter filter = filterBuilder.attribute(Metacard.MODIFIED).after().date(dateBeforeNow(now));
+        List<Result> results = getResultsForFilteredQuery(filter);
+        assertEquals(1, results.size());
+
+        /** NEGATIVE CASE **/
+        filter = filterBuilder.attribute(Metacard.MODIFIED).after().date(dateAfterNow(now));
+        results = getResultsForFilteredQuery(filter);
+        assertEquals(0, results.size());
+    }
+
+    @Test()
+    public void testDateGreaterThan() throws Exception {
+
+        deleteAllIn(provider);
+
+        DateTime now = new DateTime();
+        List<Metacard> list = addMetacardWithModifiedDate(now);
+
+        /** POSITIVE CASE **/
+        Filter filter = filterBuilder.dateGreaterThan(Metacard.MODIFIED, dateBeforeNow(now));
+        List<Result> results = getResultsForFilteredQuery(filter);
+        assertEquals(1, results.size());
+
+        /** NEGATIVE CASE **/
+        filter = filterBuilder.dateGreaterThan(Metacard.MODIFIED, dateAfterNow(now));
+        results = getResultsForFilteredQuery(filter);
+        assertEquals(0, results.size());
+    }
+
+    @Test()
+    public void testDateGreaterThanOrEqualTo() throws Exception {
+
+        deleteAllIn(provider);
+
+        DateTime now = new DateTime();
+        List<Metacard> list = addMetacardWithModifiedDate(now);
+
+        /** POSITIVE CASE **/
+        Filter filter = filterBuilder.dateGreaterThanOrEqual(Metacard.MODIFIED, dateBeforeNow(now));
+        List<Result> results = getResultsForFilteredQuery(filter);
+        assertEquals(1, results.size());
+
+        /** NEGATIVE CASE **/
+        filter = filterBuilder.dateGreaterThanOrEqual(Metacard.MODIFIED, dateAfterNow(now));
+        results = getResultsForFilteredQuery(filter);
+        assertEquals(0, results.size());
+    }
+
+    @Test()
+    public void testDateLessThan() throws Exception {
+
+        deleteAllIn(provider);
+
+        DateTime now = new DateTime();
+        List<Metacard> list = addMetacardWithModifiedDate(now);
+
+        /** POSITIVE CASE **/
+        Filter filter = filterBuilder.dateLessThan(Metacard.MODIFIED, dateAfterNow(now));
+        List<Result> results = getResultsForFilteredQuery(filter);
+        assertEquals(1, results.size());
+
+        /** NEGATIVE CASE **/
+        filter = filterBuilder.dateLessThan(Metacard.MODIFIED, dateNow(now));
+        results = getResultsForFilteredQuery(filter);
+        assertEquals(0, results.size());
+    }
+
+    @Test()
+    public void testDateLessThanOrEqualTo() throws Exception {
+
+        deleteAllIn(provider);
+
+        DateTime now = new DateTime();
+        List<Metacard> list = addMetacardWithModifiedDate(now);
+
+        /** POSITIVE CASE **/
+        Filter filter = filterBuilder.dateLessThanOrEqual(Metacard.MODIFIED, dateAfterNow(now));
+        List<Result> results = getResultsForFilteredQuery(filter);
+        assertEquals(1, results.size());
+
+        /** NEGATIVE CASE **/
+        filter = filterBuilder.dateLessThanOrEqual(Metacard.MODIFIED, dateBeforeNow(now));
+        results = getResultsForFilteredQuery(filter);
+        assertEquals(0, results.size());
     }
 
     /**
@@ -2972,7 +3053,7 @@ public class TestSolrProvider extends SolrProviderTestCase {
 
         create(list);
 
-        Filter filter = filterBuilder.attribute(Metacard.EFFECTIVE).before().date(now.toDate());
+        Filter filter = filterBuilder.attribute(Metacard.EFFECTIVE).before().date(now.plusMillis(1).toDate());
 
         QueryImpl query = new QueryImpl(filter);
 
@@ -3021,7 +3102,7 @@ public class TestSolrProvider extends SolrProviderTestCase {
 
         // Sort all TEMPORAL DESC
 
-        filter = filterBuilder.attribute(Metacard.EFFECTIVE).before().date(now.toDate());
+        filter = filterBuilder.attribute(Metacard.EFFECTIVE).before().date(now.plusMillis(1).toDate());
 
         query = new QueryImpl(filter);
 


### PR DESCRIPTION
This also corrects a bug in before() and during() where the test was inclusive, while the interface is defined as exclusive.
